### PR TITLE
feat: DMS endpoint credential from secret manager

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -160,19 +160,21 @@ resource "aws_dms_replication_instance" "this" {
 resource "aws_dms_endpoint" "this" {
   for_each = { for k, v in var.endpoints : k => v if var.create }
 
-  certificate_arn             = try(aws_dms_certificate.this[each.value.certificate_key].certificate_arn, null)
-  database_name               = lookup(each.value, "database_name", null)
-  endpoint_id                 = each.value.endpoint_id
-  endpoint_type               = each.value.endpoint_type
-  engine_name                 = each.value.engine_name
-  extra_connection_attributes = lookup(each.value, "extra_connection_attributes", null)
-  kms_key_arn                 = lookup(each.value, "kms_key_arn", null)
-  password                    = lookup(each.value, "password", null)
-  port                        = lookup(each.value, "port", null)
-  server_name                 = lookup(each.value, "server_name", null)
-  service_access_role         = lookup(each.value, "service_access_role", null)
-  ssl_mode                    = lookup(each.value, "ssl_mode", null)
-  username                    = lookup(each.value, "username", null)
+  certificate_arn                 = try(aws_dms_certificate.this[each.value.certificate_key].certificate_arn, null)
+  database_name                   = lookup(each.value, "database_name", null)
+  endpoint_id                     = each.value.endpoint_id
+  endpoint_type                   = each.value.endpoint_type
+  engine_name                     = each.value.engine_name
+  extra_connection_attributes     = lookup(each.value, "extra_connection_attributes", null)
+  kms_key_arn                     = lookup(each.value, "kms_key_arn", null)
+  password                        = lookup(each.value, "password", null)
+  port                            = lookup(each.value, "port", null)
+  server_name                     = lookup(each.value, "server_name", null)
+  service_access_role             = lookup(each.value, "service_access_role", null)
+  ssl_mode                        = lookup(each.value, "ssl_mode", null)
+  username                        = lookup(each.value, "username", null)
+  secrets_manager_arn             = lookup(each.value, "secrets_manager_arn", null)
+  secrets_manager_access_role_arn = lookup(each.value, "secrets_manager_access_role_arn", null)
 
   # https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Target.Elasticsearch.html
   dynamic "elasticsearch_settings" {


### PR DESCRIPTION
AWS DMS endpoint resource now(https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dms_endpoint#secrets_manager_access_role_arn) supports getting credentials from secret manager. 

## Description
AWS DMS endpoint resource now(https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dms_endpoint#secrets_manager_access_role_arn) supports getting credentials from secret manager. This two line change allows users of the module to configure the DMS credentials from the secret manager. 

`  secrets_manager_arn             = lookup(each.value, "secrets_manager_arn", null)
  secrets_manager_access_role_arn = lookup(each.value, "secrets_manager_access_role_arn", null)`

## Motivation and Context
Getting credentials from secret manager for DMS  is particularly useful when the database credentials has special characters which RDS supports but the DMS does not support.
![Screen Shot 2022-04-28 at 6 47 13 PM](https://user-images.githubusercontent.com/79213542/166313596-5ad9f723-8e1d-46b0-bbd7-de4adcb16921.png)


## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects. I have tested the changes from my local branch. 
