### PR TITLE
fix: Replace local-exec sleep with time_sleep

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.72.2
+    rev: v1.74.1
     hooks:
       - id: terraform_fmt
       - id: terraform_validate

--- a/README.md
+++ b/README.md
@@ -304,12 +304,14 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
 | <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.6 |
+| <a name="requirement_time"></a> [time](#requirement\_time) | >=0.7.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
 | <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.6 |
+| <a name="provider_time"></a> [time](#provider\_time) | >=0.7.2 |
 
 ## Modules
 
@@ -328,6 +330,7 @@ No modules.
 | [aws_iam_role.dms_access_for_endpoint](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.dms_cloudwatch_logs_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
 | [aws_iam_role.dms_vpc_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [time_sleep.wait_for_dependency_resources](https://registry.terraform.io/providers/hashicorp/time/latest/docs/resources/sleep) | resource |
 | [aws_iam_policy_document.dms_assume_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_iam_policy_document.dms_assume_role_redshift](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/iam_policy_document) | data source |
 | [aws_partition.current](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/partition) | data source |

--- a/main.tf
+++ b/main.tf
@@ -41,7 +41,7 @@ data "aws_iam_policy_document" "dms_assume_role_redshift" {
   }
 }
 
-# Time sleep to delay dependency resource creation and deletion
+# Time Sleep
 resource "time_sleep" "wait_for_dependency_resources" {
   depends_on = [
     aws_iam_role.dms_access_for_endpoint,

--- a/main.tf
+++ b/main.tf
@@ -49,7 +49,7 @@ resource "time_sleep" "wait_for_dependency_resources" {
     aws_iam_role.dms_vpc_role
   ]
 
-  create_duration = "10s"
+  create_duration  = "10s"
   destroy_duration = "10s"
 }
 

--- a/main.tf
+++ b/main.tf
@@ -46,7 +46,7 @@ resource "time_sleep" "wait_for_dependency_resources" {
   depends_on = [
     aws_iam_role.dms_access_for_endpoint,
     aws_iam_role.dms_cloudwatch_logs_role,
-    aws_iam_role.dms_vpc_role,
+    aws_iam_role.dms_vpc_role
   ]
 
   create_duration = "10s"

--- a/versions.tf
+++ b/versions.tf
@@ -6,5 +6,9 @@ terraform {
       source  = "hashicorp/aws"
       version = ">= 4.6"
     }
+    time = {
+      source  = "hashicorp/time"
+      version = ">=0.7.2"
+    }
   }
 }


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Replace `local-exec sleep` with `time_sleep` to wait for dependency resources to get created and destroyed properly.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
As per: https://github.com/hashicorp/terraform-provider-aws/issues/11025#issuecomment-660059684, using `local-exec sleep` was a temporary fix, `time_sleep` is more suited for specifically managing cross-platform compatibility and destroy-time issues.


## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
N/A

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->

CC: @antonbabenko 