### PR TITLE
[WIP] feat: Allow conditional creation of task, instance, endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -341,8 +341,11 @@ No modules.
 |------|-------------|------|---------|:--------:|
 | <a name="input_certificates"></a> [certificates](#input\_certificates) | Map of objects that define the certificates to be created | `map(any)` | `{}` | no |
 | <a name="input_create"></a> [create](#input\_create) | Determines whether resources will be created | `bool` | `true` | no |
+| <a name="input_create_endpoints"></a> [create\_endpoints](#input\_create\_endpoints) | Determines whether any endpoints will be created | `bool` | `true` | no |
 | <a name="input_create_iam_roles"></a> [create\_iam\_roles](#input\_create\_iam\_roles) | Determines whether the required [DMS IAM resources](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Security.html#CHAP_Security.APIRole) will be created | `bool` | `true` | no |
+| <a name="input_create_repl_instance"></a> [create\_repl\_instance](#input\_create\_repl\_instance) | Determines whether the replication instance will be created | `bool` | `true` | no |
 | <a name="input_create_repl_subnet_group"></a> [create\_repl\_subnet\_group](#input\_create\_repl\_subnet\_group) | Determines whether the replication subnet group will be created | `bool` | `true` | no |
+| <a name="input_create_repl_task"></a> [create\_repl\_task](#input\_create\_repl\_task) | Determines whether any replication tasks will be created | `bool` | `true` | no |
 | <a name="input_enable_redshift_target_permissions"></a> [enable\_redshift\_target\_permissions](#input\_enable\_redshift\_target\_permissions) | Determines whether `redshift.amazonaws.com` is permitted access to assume the `dms-access-for-endpoint` role | `bool` | `false` | no |
 | <a name="input_endpoints"></a> [endpoints](#input\_endpoints) | Map of objects that define the endpoints to be created | `any` | `{}` | no |
 | <a name="input_event_subscription_timeouts"></a> [event\_subscription\_timeouts](#input\_event\_subscription\_timeouts) | A map of timeouts for event subscription create/update/delete operations | `map(string)` | `{}` | no |

--- a/main.tf
+++ b/main.tf
@@ -43,6 +43,7 @@ data "aws_iam_policy_document" "dms_assume_role_redshift" {
 
 # Time Sleep
 resource "time_sleep" "wait_for_dependency_resources" {
+  count = var.create && (var.create_repl_subnet_group || var.create_repl_instance) ? 1 : 0
   depends_on = [
     aws_iam_role.dms_access_for_endpoint,
     aws_iam_role.dms_cloudwatch_logs_role,

--- a/main.tf
+++ b/main.tf
@@ -116,7 +116,7 @@ resource "aws_dms_replication_subnet_group" "this" {
 ################################################################################
 
 resource "aws_dms_replication_instance" "this" {
-  count = var.create ? 1 : 0
+  count = var.create && var.create_repl_instance ? 1 : 0
 
   allocated_storage            = var.repl_instance_allocated_storage
   auto_minor_version_upgrade   = var.repl_instance_auto_minor_version_upgrade
@@ -149,7 +149,7 @@ resource "aws_dms_replication_instance" "this" {
 ################################################################################
 
 resource "aws_dms_endpoint" "this" {
-  for_each = { for k, v in var.endpoints : k => v if var.create }
+  for_each = { for k, v in var.endpoints : k => v if var.create && var.create_endpoints }
 
   certificate_arn             = try(aws_dms_certificate.this[each.value.certificate_key].certificate_arn, null)
   database_name               = lookup(each.value, "database_name", null)
@@ -287,7 +287,7 @@ resource "aws_dms_endpoint" "this" {
 ################################################################################
 
 resource "aws_dms_replication_task" "this" {
-  for_each = { for k, v in var.replication_tasks : k => v if var.create }
+  for_each = { for k, v in var.replication_tasks : k => v if var.create && var.create_repl_task }
 
   cdc_start_position        = lookup(each.value, "cdc_start_position", null)
   cdc_start_time            = lookup(each.value, "cdc_start_time", null)

--- a/variables.tf
+++ b/variables.tf
@@ -67,6 +67,12 @@ variable "repl_subnet_group_tags" {
 }
 
 # Instance
+variable "create_repl_instance" {
+  description = "Determines whether the replication instance will be created"
+  type        = bool
+  default     = true
+}
+
 variable "repl_instance_allocated_storage" {
   description = "The amount of storage (in gigabytes) to be initially allocated for the replication instance. Min: 5, Max: 6144, Default: 50"
   type        = number
@@ -164,6 +170,12 @@ variable "repl_instance_timeouts" {
 }
 
 # Replication Tasks
+variable "create_repl_task" {
+  description = "Determines whether any replication tasks will be created"
+  type        = bool
+  default     = true
+}
+
 variable "replication_tasks" {
   description = "Map of objects that define the replication tasks to be created"
   type        = any
@@ -172,6 +184,12 @@ variable "replication_tasks" {
 
 
 # Endpoints
+variable "create_endpoints" {
+  description = "Determines whether any endpoints will be created"
+  type        = bool
+  default     = true
+}
+
 variable "endpoints" {
   description = "Map of objects that define the endpoints to be created"
   type        = any


### PR DESCRIPTION
## Description
I am adding three `create_xxx` variables to cater for the conditional creation of `aws_dms_replication_instance`, `aws_dms_endpoint` and `aws_dms_replication_task` resources.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/terraform-aws-modules/terraform-aws-dms/issues/25, in the way discussed.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No breaking changes. The new `create_xxx` variables are set with default value `true`.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [X] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
