### PR TITLE
feat: Added support for secretsmanager secret in endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,14 +303,14 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.6 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.17 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >=0.7.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.6 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.17 |
 | <a name="provider_time"></a> [time](#provider\_time) | >=0.7.2 |
 
 ## Modules

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -58,11 +58,15 @@ Note that this example may create resources which will incur monetary charges on
 | Name | Type |
 |------|------|
 | [aws_iam_role.s3_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_iam_role.secretsmanager_role](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/iam_role) | resource |
+| [aws_kms_key.aurora_credentials](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_kms_key.msk](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
 | [aws_rds_cluster_parameter_group.postgresql](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster_parameter_group) | resource |
 | [aws_s3_object.hr_data](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/s3_object) | resource |
+| [aws_secretsmanager_secret.aurora_credentials](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret.msk](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret) | resource |
 | [aws_secretsmanager_secret_policy.msk](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_policy) | resource |
+| [aws_secretsmanager_secret_version.aurora_credentials](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [aws_secretsmanager_secret_version.msk](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/secretsmanager_secret_version) | resource |
 | [aws_sns_topic.example](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/sns_topic) | resource |
 | [random_pet.this](https://registry.terraform.io/providers/hashicorp/random/latest/docs/resources/pet) | resource |

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -28,14 +28,14 @@ Note that this example may create resources which will incur monetary charges on
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.6 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.17 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.6 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.17 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0 |
 
 ## Modules

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.6"
+      version = ">= 4.17"
     }
     random = {
       source  = "hashicorp/random"

--- a/main.tf
+++ b/main.tf
@@ -151,19 +151,21 @@ resource "aws_dms_replication_instance" "this" {
 resource "aws_dms_endpoint" "this" {
   for_each = { for k, v in var.endpoints : k => v if var.create }
 
-  certificate_arn             = try(aws_dms_certificate.this[each.value.certificate_key].certificate_arn, null)
-  database_name               = lookup(each.value, "database_name", null)
-  endpoint_id                 = each.value.endpoint_id
-  endpoint_type               = each.value.endpoint_type
-  engine_name                 = each.value.engine_name
-  extra_connection_attributes = lookup(each.value, "extra_connection_attributes", null)
-  kms_key_arn                 = lookup(each.value, "kms_key_arn", null)
-  password                    = lookup(each.value, "password", null)
-  port                        = lookup(each.value, "port", null)
-  server_name                 = lookup(each.value, "server_name", null)
-  service_access_role         = lookup(each.value, "service_access_role", null)
-  ssl_mode                    = lookup(each.value, "ssl_mode", null)
-  username                    = lookup(each.value, "username", null)
+  certificate_arn                 = try(aws_dms_certificate.this[each.value.certificate_key].certificate_arn, null)
+  database_name                   = lookup(each.value, "database_name", null)
+  endpoint_id                     = each.value.endpoint_id
+  endpoint_type                   = each.value.endpoint_type
+  engine_name                     = each.value.engine_name
+  extra_connection_attributes     = lookup(each.value, "extra_connection_attributes", null)
+  kms_key_arn                     = lookup(each.value, "kms_key_arn", null)
+  password                        = lookup(each.value, "password", null)
+  port                            = lookup(each.value, "port", null)
+  server_name                     = lookup(each.value, "server_name", null)
+  service_access_role             = lookup(each.value, "service_access_role", null)
+  ssl_mode                        = lookup(each.value, "ssl_mode", null)
+  username                        = lookup(each.value, "username", null)
+  secrets_manager_access_role_arn = lookup(each.value, "secrets_manager_access_role_arn", null)
+  secrets_manager_arn             = lookup(each.value, "secrets_manager_arn", null)
 
   # https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Target.Elasticsearch.html
   dynamic "elasticsearch_settings" {

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.6"
+      version = ">= 4.17"
     }
     time = {
       source  = "hashicorp/time"


### PR DESCRIPTION
## Description
Adding the ability to configure aws_dms_endpoint database connection details via a SecretsManager secret.
Reference: https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dms_endpoint#secrets_manager_access_role_arn

## Motivation and Context
This is supported in the Terraform provider and provides a nice way to securely pass the database connection details.
AWS documentation:
* https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Security.html#security_iam_secretsmanager
* https://docs.aws.amazon.com/secretsmanager/latest/userguide/vpc-endpoint-overview.html#vpc-endpoint

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No breaking changes.

## How Has This Been Tested?
- [X] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [X] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [X] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
