### PR TITLE
Add support for configuring expected_bucket_owner

### DIFF
--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -97,6 +97,7 @@ module "dms_aurora_postgresql_aurora_mysql" {
         bucket_name               = local.bucket_name # to avoid https://github.com/hashicorp/terraform/issues/4149
         data_format               = "csv"
         encryption_mode           = "SSE_S3"
+        expected_bucket_owner     = data.aws_caller_identity.current.account_id
         external_table_definition = file("configs/s3_table_definition.json")
         service_access_role_arn   = "arn:${data.aws_partition.current.partition}:iam::${data.aws_caller_identity.current.account_id}:role/${local.name}-s3" # to avoid https://github.com/hashicorp/terraform/issues/4149
       }

--- a/main.tf
+++ b/main.tf
@@ -265,6 +265,7 @@ resource "aws_dms_endpoint" "this" {
       enable_statistics                 = lookup(s3_settings.value, "enable_statistics", null)
       encoding_type                     = lookup(s3_settings.value, "encoding_type", null)
       encryption_mode                   = lookup(s3_settings.value, "encryption_mode", null)
+      expected_bucket_owner             = lookup(s3_settings.value, "expected_bucket_owner", null)
       external_table_definition         = lookup(s3_settings.value, "external_table_definition", null)
       ignore_headers_row                = lookup(s3_settings.value, "ignore_headers_row", null)
       include_op_for_full_load          = lookup(s3_settings.value, "include_op_for_full_load", null)


### PR DESCRIPTION
## Description

The s3_settings example and `main.tf` in this module are missing the
`expected_bucket_owner` optional attribute.

- [x] Adding the `expected_bucket_owner` to s3_settings;
- [x] Adding expected_bucket_owner to complete example

## Motivation and Context

From the documentation found in the Terraform registry, I've noticed that the
`expected_bucket_owner` optional argument is missing. My team and I have found
that we are using this attribute to ensure that we're able to configure S3
Target DMS Endpoints to expect a specific bucket owner. Until this gets merged
into the default branch, we will have to use a fork.

[=> Documentation found in the Terraform registry around _Resource:
aws_dms_s3_endpoint_](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dms_s3_endpoint#expected_bucket_owner)

## Breaking Changes

No breaking changes as leaving the optional property out will not cause any side
effects.

## How Has This Been Tested?

- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
    - My team is doing this in a private repository that I cannot linked to. But
      as mentioned above, the logic of adding this property is documented in the
      official AWS Provider in the Terraform Registry.
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
