### PR TITLE
fix: Update aws provider version to restore support for ignore_header_row

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,14 +303,14 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.49.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.49.0, < 5.0.0 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >=0.7.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.49.0 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.49.0, < 5.0.0 |
 | <a name="provider_time"></a> [time](#provider\_time) | >=0.7.2 |
 
 ## Modules

--- a/README.md
+++ b/README.md
@@ -303,14 +303,14 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.17 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.49.0 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >=0.7.2 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.17 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.49.0 |
 | <a name="provider_time"></a> [time](#provider\_time) | >=0.7.2 |
 
 ## Modules

--- a/examples/complete/README.md
+++ b/examples/complete/README.md
@@ -28,14 +28,14 @@ Note that this example may create resources which will incur monetary charges on
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 0.13.1 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.17 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 4.49.0, < 5.0.0 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.17 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 4.49.0, < 5.0.0 |
 | <a name="provider_random"></a> [random](#provider\_random) | >= 3.0 |
 
 ## Modules

--- a/examples/complete/versions.tf
+++ b/examples/complete/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.17"
+      version = ">= 4.49.0, < 5.0.0"
     }
     random = {
       source  = "hashicorp/random"

--- a/main.tf
+++ b/main.tf
@@ -266,7 +266,7 @@ resource "aws_dms_endpoint" "this" {
       encoding_type                     = lookup(s3_settings.value, "encoding_type", null)
       encryption_mode                   = lookup(s3_settings.value, "encryption_mode", null)
       external_table_definition         = lookup(s3_settings.value, "external_table_definition", null)
-      ignore_headers_row                = lookup(s3_settings.value, "ignore_headers_row", null)
+      ignore_header_rows                = lookup(s3_settings.value, "ignore_header_rows", null)
       include_op_for_full_load          = lookup(s3_settings.value, "include_op_for_full_load", null)
       max_file_size                     = lookup(s3_settings.value, "max_file_size", null)
       parquet_timestamp_in_millisecond  = lookup(s3_settings.value, "parquet_timestamp_in_millisecond", null)

--- a/main.tf
+++ b/main.tf
@@ -266,7 +266,7 @@ resource "aws_dms_endpoint" "this" {
       encoding_type                     = lookup(s3_settings.value, "encoding_type", null)
       encryption_mode                   = lookup(s3_settings.value, "encryption_mode", null)
       external_table_definition         = lookup(s3_settings.value, "external_table_definition", null)
-      ignore_header_rows                = lookup(s3_settings.value, "ignore_header_rows", null)
+      ignore_headers_row                = lookup(s3_settings.value, "ignore_headers_row", null)
       include_op_for_full_load          = lookup(s3_settings.value, "include_op_for_full_load", null)
       max_file_size                     = lookup(s3_settings.value, "max_file_size", null)
       parquet_timestamp_in_millisecond  = lookup(s3_settings.value, "parquet_timestamp_in_millisecond", null)

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.49.0"
+      version = ">= 4.49.0, < 5.0.0"
     }
     time = {
       source  = "hashicorp/time"

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 4.17"
+      version = ">= 4.49.0"
     }
     time = {
       source  = "hashicorp/time"


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
Terraform provider in [version 4.49.0 gets a fix](https://github.com/hashicorp/terraform-provider-aws/pull/28579) that allows setting `IgnoreHeaderRows`, with a fallback on `ignore_header_row` besides `ignore_header_rows`.
In version [5.0.0 of the provider, the fallback is removed ](https://github.com/hashicorp/terraform-provider-aws/releases/tag/v5.0.0) and there are many other breaking changes that affects this module and underlying VPC module.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Fixes https://github.com/terraform-aws-modules/terraform-aws-dms/issues/38


## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
