### PR TITLE
fix: Variablize role names

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -57,7 +57,7 @@ resource "time_sleep" "wait_for_dependency_resources" {
 resource "aws_iam_role" "dms_access_for_endpoint" {
   count = var.create && var.create_iam_roles ? 1 : 0
 
-  name                  = "dms-access-for-endpoint"
+  name                  = var.dms_access_for_endpoint_role_name
   description           = "DMS IAM role for endpoint access permissions"
   permissions_boundary  = var.iam_role_permissions_boundary
   assume_role_policy    = var.enable_redshift_target_permissions ? data.aws_iam_policy_document.dms_assume_role_redshift[0].json : data.aws_iam_policy_document.dms_assume_role[0].json
@@ -71,7 +71,7 @@ resource "aws_iam_role" "dms_access_for_endpoint" {
 resource "aws_iam_role" "dms_cloudwatch_logs_role" {
   count = var.create && var.create_iam_roles ? 1 : 0
 
-  name                  = "dms-cloudwatch-logs-role"
+  name                  = var.dms_cloudwatch_logs_role_name
   description           = "DMS IAM role for CloudWatch logs permissions"
   permissions_boundary  = var.iam_role_permissions_boundary
   assume_role_policy    = data.aws_iam_policy_document.dms_assume_role[0].json
@@ -85,7 +85,7 @@ resource "aws_iam_role" "dms_cloudwatch_logs_role" {
 resource "aws_iam_role" "dms_vpc_role" {
   count = var.create && var.create_iam_roles ? 1 : 0
 
-  name                  = "dms-vpc-role"
+  name                  = var.dms_vpc_role_name
   description           = "DMS IAM role for VPC permissions"
   permissions_boundary  = var.iam_role_permissions_boundary
   assume_role_policy    = data.aws_iam_policy_document.dms_assume_role[0].json

--- a/variables.tf
+++ b/variables.tf
@@ -17,6 +17,24 @@ variable "create_iam_roles" {
   default     = true
 }
 
+variable "dms_access_for_endpoint_role_name" {
+  description = "Name of the DMS IAM role for endpoint access"
+  type        = string
+  default     = "dms-access-for-endpoint"
+}
+
+variable "dms_cloudwatch_logs_role_name" {
+  description = "Name of the DMS IAM role for CloudWatch logs"
+  type        = string
+  default     = "dms-cloudwatch-logs-role"
+}
+
+variable "dms_vpc_role_name" {
+  description = "Name of the DMS IAM role for VPC"
+  type        = string
+  default     = "dms-vpc-role"
+}
+
 variable "iam_role_permissions_boundary" {
   description = "ARN of the policy that is used to set the permissions boundary for the role"
   type        = string


### PR DESCRIPTION
## Description
Cannot reuse this module in same account as the role names are already exists.


## Motivation and Context
This will allow the module to be used multiple times in same account

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? --> no

