### PR TITLE
chore!: change IAM names to dynamic

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -44,7 +44,7 @@ data "aws_iam_policy_document" "dms_assume_role_redshift" {
 resource "aws_iam_role" "dms_access_for_endpoint" {
   count = var.create && var.create_iam_roles ? 1 : 0
 
-  name                  = "dms-access-for-endpoint"
+  name_prefix           = "dms-access-for-endpoint-"
   description           = "DMS IAM role for endpoint access permissions"
   permissions_boundary  = var.iam_role_permissions_boundary
   assume_role_policy    = var.enable_redshift_target_permissions ? data.aws_iam_policy_document.dms_assume_role_redshift[0].json : data.aws_iam_policy_document.dms_assume_role[0].json
@@ -63,7 +63,7 @@ resource "aws_iam_role" "dms_access_for_endpoint" {
 resource "aws_iam_role" "dms_cloudwatch_logs_role" {
   count = var.create && var.create_iam_roles ? 1 : 0
 
-  name                  = "dms-cloudwatch-logs-role"
+  name_prefix           = "dms-cloudwatch-logs-role-"
   description           = "DMS IAM role for CloudWatch logs permissions"
   permissions_boundary  = var.iam_role_permissions_boundary
   assume_role_policy    = data.aws_iam_policy_document.dms_assume_role[0].json
@@ -82,7 +82,7 @@ resource "aws_iam_role" "dms_cloudwatch_logs_role" {
 resource "aws_iam_role" "dms_vpc_role" {
   count = var.create && var.create_iam_roles ? 1 : 0
 
-  name                  = "dms-vpc-role"
+  name_prefix           = "dms-vpc-role-"
   description           = "DMS IAM role for VPC permissions"
   permissions_boundary  = var.iam_role_permissions_boundary
   assume_role_policy    = data.aws_iam_policy_document.dms_assume_role[0].json


### PR DESCRIPTION
## Description
Instead of use predefined IAM names which could lead to confusing when there are few projects in the same AWS account, I suggest to use `name_prefix` to generate unique per-project names for these resources.

## Motivation and Context
Imagine you create more than 1 project in a AWS account. Currently, because IAM resources have hardcoded names, it's impossible to make multiple projects - you'll have an error "such aws resource already exists". With proposed changes, we eliminate the issue.


## Breaking Changes
It breaks backwards compatibility just in terms of recreate IAM resources with new names.

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
