### PR TITLE
fix: Add conditional to access IAM role when used as fallback value

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
   - repo: https://github.com/antonbabenko/pre-commit-terraform
-    rev: v1.82.0
+    rev: v1.83.5
     hooks:
       - id: terraform_fmt
       - id: terraform_validate
@@ -23,7 +23,7 @@ repos:
           - '--args=--only=terraform_standard_module_structure'
           - '--args=--only=terraform_workspace_remote'
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v4.4.0
+    rev: v4.5.0
     hooks:
       - id: check-merge-conflict
       - id: end-of-file-fixer

--- a/main.tf
+++ b/main.tf
@@ -232,7 +232,7 @@ resource "aws_dms_endpoint" "this" {
       include_transaction_details    = try(kinesis_settings.value.include_transaction_details, null)
       message_format                 = try(kinesis_settings.value.message_format, null)
       partition_include_schema_table = try(kinesis_settings.value.partition_include_schema_table, null)
-      service_access_role_arn        = lookup(kinesis_settings.value, "service_access_role_arn", aws_iam_role.access[0].arn)
+      service_access_role_arn        = lookup(kinesis_settings.value, "service_access_role_arn", var.create_access_iam_role ? aws_iam_role.access[0].arn : null)
       stream_arn                     = lookup(kinesis_settings.value, "stream_arn", null)
     }
   }
@@ -282,10 +282,10 @@ resource "aws_dms_endpoint" "this" {
     }
   }
 
-  secrets_manager_access_role_arn = lookup(each.value, "secrets_manager_arn", null) != null ? lookup(each.value, "secrets_manager_access_role_arn", aws_iam_role.access[0].arn) : null
+  secrets_manager_access_role_arn = lookup(each.value, "secrets_manager_arn", null) != null ? lookup(each.value, "secrets_manager_access_role_arn", var.create_access_iam_role ? aws_iam_role.access[0].arn : null) : null
   secrets_manager_arn             = lookup(each.value, "secrets_manager_arn", null)
   server_name                     = lookup(each.value, "server_name", null)
-  service_access_role             = lookup(each.value, "service_access_role", aws_iam_role.access[0].arn)
+  service_access_role             = lookup(each.value, "service_access_role", var.create_access_iam_role ? aws_iam_role.access[0].arn : null)
   ssl_mode                        = try(each.value.ssl_mode, null)
   username                        = try(each.value.username, null)
 
@@ -344,7 +344,7 @@ resource "aws_dms_s3_endpoint" "this" {
   rfc_4180                                    = try(each.value.rfc_4180, null)
   row_group_length                            = try(each.value.row_group_length, null)
   server_side_encryption_kms_key_id           = lookup(each.value, "server_side_encryption_kms_key_id", null)
-  service_access_role_arn                     = lookup(each.value, "service_access_role_arn", aws_iam_role.access[0].arn)
+  service_access_role_arn                     = lookup(each.value, "service_access_role_arn", var.create_access_iam_role ? aws_iam_role.access[0].arn : null)
   timestamp_column_name                       = try(each.value.timestamp_column_name, null)
   use_csv_no_sup_value                        = try(each.value.use_csv_no_sup_value, null)
   use_task_start_time_for_full_load_timestamp = try(each.value.use_task_start_time_for_full_load_timestamp, null)

--- a/main.tf
+++ b/main.tf
@@ -232,7 +232,7 @@ resource "aws_dms_endpoint" "this" {
       include_transaction_details    = try(kinesis_settings.value.include_transaction_details, null)
       message_format                 = try(kinesis_settings.value.message_format, null)
       partition_include_schema_table = try(kinesis_settings.value.partition_include_schema_table, null)
-      service_access_role_arn        = lookup(kinesis_settings.value, "service_access_role_arn", var.create_access_iam_role ? aws_iam_role.access[0].arn : null)
+      service_access_role_arn        = lookup(kinesis_settings.value, "service_access_role_arn", local.access_iam_role)
       stream_arn                     = lookup(kinesis_settings.value, "stream_arn", null)
     }
   }
@@ -282,10 +282,10 @@ resource "aws_dms_endpoint" "this" {
     }
   }
 
-  secrets_manager_access_role_arn = lookup(each.value, "secrets_manager_arn", null) != null ? lookup(each.value, "secrets_manager_access_role_arn", var.create_access_iam_role ? aws_iam_role.access[0].arn : null) : null
+  secrets_manager_access_role_arn = lookup(each.value, "secrets_manager_arn", null) != null ? lookup(each.value, "secrets_manager_access_role_arn", local.access_iam_role) : null
   secrets_manager_arn             = lookup(each.value, "secrets_manager_arn", null)
   server_name                     = lookup(each.value, "server_name", null)
-  service_access_role             = lookup(each.value, "service_access_role", var.create_access_iam_role ? aws_iam_role.access[0].arn : null)
+  service_access_role             = lookup(each.value, "service_access_role", local.access_iam_role)
   ssl_mode                        = try(each.value.ssl_mode, null)
   username                        = try(each.value.username, null)
 
@@ -344,7 +344,7 @@ resource "aws_dms_s3_endpoint" "this" {
   rfc_4180                                    = try(each.value.rfc_4180, null)
   row_group_length                            = try(each.value.row_group_length, null)
   server_side_encryption_kms_key_id           = lookup(each.value, "server_side_encryption_kms_key_id", null)
-  service_access_role_arn                     = lookup(each.value, "service_access_role_arn", var.create_access_iam_role ? aws_iam_role.access[0].arn : null)
+  service_access_role_arn                     = lookup(each.value, "service_access_role_arn", local.access_iam_role)
   timestamp_column_name                       = try(each.value.timestamp_column_name, null)
   use_csv_no_sup_value                        = try(each.value.use_csv_no_sup_value, null)
   use_task_start_time_for_full_load_timestamp = try(each.value.use_task_start_time_for_full_load_timestamp, null)
@@ -429,6 +429,8 @@ locals {
   access_iam_role_name   = try(coalesce(var.access_iam_role_name, var.repl_instance_id), "")
   create_access_iam_role = var.create && var.create_access_iam_role
   create_access_policy   = local.create_access_iam_role && var.create_access_policy
+
+  access_iam_role = local.create_access_iam_role ? aws_iam_role.access[0].arn : null
 }
 
 data "aws_iam_policy_document" "access_assume" {


### PR DESCRIPTION
## Description
Added a ternary on create_access_iam_role on lookups for `service_access_role_arn` in aws_dms_endpoint.this.kinesis settings, `secrets_manager_access_role_arn` and `service_access_role` in aws_dms_endpoint.this. I did not add the ternary to the elasticsearch block as the role is required in that context. However, using an already defined role will likely cause a failure here for the same reason, but I did not test this scenario as I am not using elasticsearch with DMS. 

## Motivation and Context
Implementations of the module where roles have already been provisioned for access and are passed to the necessary objects resulted in a failure when `create_access_iam_role = false` due to ` aws_iam_role.access[0].arn` is an empty tuple. 

- Resolves #47 

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
This should not introduce any breaking changes.
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have deployed this change against my existing DMS implementation after updating to 2.0.0
`No changes. Your infrastructure matches the configuration.`
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
