### PR TITLE
chore: Bump repl_instance_engine_version to 3.5.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ module "database_migration_service" {
   repl_instance_auto_minor_version_upgrade   = true
   repl_instance_allow_major_version_upgrade  = true
   repl_instance_apply_immediately            = true
-  repl_instance_engine_version               = "3.4.5"
+  repl_instance_engine_version               = "3.5.2"
   repl_instance_multi_az                     = true
   repl_instance_preferred_maintenance_window = "sun:10:30-sun:14:30"
   repl_instance_publicly_accessible          = false

--- a/examples/complete/main.tf
+++ b/examples/complete/main.tf
@@ -76,7 +76,7 @@ module "dms_aurora_postgresql_aurora_mysql" {
   repl_instance_auto_minor_version_upgrade   = true
   repl_instance_allow_major_version_upgrade  = true
   repl_instance_apply_immediately            = true
-  repl_instance_engine_version               = "3.5.1"
+  repl_instance_engine_version               = "3.5.2"
   repl_instance_multi_az                     = true
   repl_instance_preferred_maintenance_window = "sun:10:30-sun:14:30"
   repl_instance_publicly_accessible          = false


### PR DESCRIPTION
## Description

- use the latest repl_instance-engine

see release notes, https://docs.aws.amazon.com/dms/latest/userguide/CHAP_ReleaseNotes.html
