### PR TITLE
feat: Add Serverless replication task support

### DIFF
--- a/README.md
+++ b/README.md
@@ -303,14 +303,14 @@ Examples codified under the [`examples`](https://github.com/terraform-aws-module
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.31 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32 |
 | <a name="requirement_time"></a> [time](#requirement\_time) | >= 0.9 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.31 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32 |
 | <a name="provider_time"></a> [time](#provider\_time) | >= 0.9 |
 
 ## Modules
@@ -428,7 +428,7 @@ No modules.
 | <a name="output_replication_subnet_group_id"></a> [replication\_subnet\_group\_id](#output\_replication\_subnet\_group\_id) | The ID of the subnet group |
 | <a name="output_replication_tasks"></a> [replication\_tasks](#output\_replication\_tasks) | A map of maps containing the replication tasks created and their full output of attributes and values |
 | <a name="output_s3_endpoints"></a> [s3\_endpoints](#output\_s3\_endpoints) | A map of maps containing the S3 endpoints created and their full output of attributes and values |
-| <a name="output_serverless_replication_tasks"></a> [serverless\_replication\_tasks](#output\_serverless\_replication\_tasks) | value |
+| <a name="output_serverless_replication_tasks"></a> [serverless\_replication\_tasks](#output\_serverless\_replication\_tasks) | A map of maps containing the serverless replication tasks (replication\_config) created and their full output of attributes and values |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## License

--- a/README.md
+++ b/README.md
@@ -296,6 +296,7 @@ Tasks are the "jobs" that perform the necessary actions of migrating from `sourc
 Examples codified under the [`examples`](https://github.com/terraform-aws-modules/terraform-aws-dms/tree/master/examples) are intended to give users references for how to use the module(s) as well as testing/validating changes to the source code of the module. If contributing to the project, please be sure to make any appropriate updates to the relevant examples to allow maintainers to test your changes and to keep the examples up to date for users. Thank you!
 
 - [Complete](https://github.com/terraform-aws-modules/terraform-aws-dms/tree/master/examples/complete)
+- [Serverless](https://github.com/terraform-aws-modules/terraform-aws-dms/tree/master/examples/serverless)
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 ## Requirements

--- a/README.md
+++ b/README.md
@@ -324,6 +324,7 @@ No modules.
 | [aws_dms_certificate.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dms_certificate) | resource |
 | [aws_dms_endpoint.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dms_endpoint) | resource |
 | [aws_dms_event_subscription.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dms_event_subscription) | resource |
+| [aws_dms_replication_config.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dms_replication_config) | resource |
 | [aws_dms_replication_instance.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dms_replication_instance) | resource |
 | [aws_dms_replication_subnet_group.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dms_replication_subnet_group) | resource |
 | [aws_dms_replication_task.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/dms_replication_task) | resource |
@@ -368,6 +369,7 @@ No modules.
 | <a name="input_create_access_iam_role"></a> [create\_access\_iam\_role](#input\_create\_access\_iam\_role) | Determines whether the ECS task definition IAM role should be created | `bool` | `true` | no |
 | <a name="input_create_access_policy"></a> [create\_access\_policy](#input\_create\_access\_policy) | Determines whether the IAM policy should be created | `bool` | `true` | no |
 | <a name="input_create_iam_roles"></a> [create\_iam\_roles](#input\_create\_iam\_roles) | Determines whether the required [DMS IAM resources](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Security.html#CHAP_Security.APIRole) will be created | `bool` | `true` | no |
+| <a name="input_create_repl_instance"></a> [create\_repl\_instance](#input\_create\_repl\_instance) | Indicates whether a replication instace should be created | `bool` | `true` | no |
 | <a name="input_create_repl_subnet_group"></a> [create\_repl\_subnet\_group](#input\_create\_repl\_subnet\_group) | Determines whether the replication subnet group will be created | `bool` | `true` | no |
 | <a name="input_enable_redshift_target_permissions"></a> [enable\_redshift\_target\_permissions](#input\_enable\_redshift\_target\_permissions) | Determines whether `redshift.amazonaws.com` is permitted access to assume the `dms-access-for-endpoint` role | `bool` | `false` | no |
 | <a name="input_endpoints"></a> [endpoints](#input\_endpoints) | Map of objects that define the endpoints to be created | `any` | `{}` | no |
@@ -426,6 +428,7 @@ No modules.
 | <a name="output_replication_subnet_group_id"></a> [replication\_subnet\_group\_id](#output\_replication\_subnet\_group\_id) | The ID of the subnet group |
 | <a name="output_replication_tasks"></a> [replication\_tasks](#output\_replication\_tasks) | A map of maps containing the replication tasks created and their full output of attributes and values |
 | <a name="output_s3_endpoints"></a> [s3\_endpoints](#output\_s3\_endpoints) | A map of maps containing the S3 endpoints created and their full output of attributes and values |
+| <a name="output_serverless_replication_tasks"></a> [serverless\_replication\_tasks](#output\_serverless\_replication\_tasks) | value |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 ## License

--- a/examples/README.md
+++ b/examples/README.md
@@ -1,3 +1,4 @@
 # Terraform AWS DMS examples
 
 - [Complete](https://github.com/terraform-aws-modules/terraform-aws-dms/tree/master/examples/complete)
+- [Serverless](https://github.com/terraform-aws-modules/terraform-aws-dms/tree/master/examples/serverless)

--- a/examples/serverless/README.md
+++ b/examples/serverless/README.md
@@ -21,6 +21,61 @@ $ terraform apply
 Note that this example may create resources which will incur monetary charges on your AWS bill. Run `terraform destroy` when you no longer need these resources.
 
 <!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+## Requirements
+
+| Name | Version |
+|------|---------|
+| <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.31 |
+| <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
+
+## Providers
+
+| Name | Version |
+|------|---------|
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.31 |
+
+## Modules
+
+| Name | Source | Version |
+|------|--------|---------|
+| <a name="module_dms_aurora_postgresql_aurora_mysql"></a> [dms\_aurora\_postgresql\_aurora\_mysql](#module\_dms\_aurora\_postgresql\_aurora\_mysql) | ../.. | n/a |
+| <a name="module_rds_aurora"></a> [rds\_aurora](#module\_rds\_aurora) | terraform-aws-modules/rds-aurora/aws | ~> 8.0 |
+| <a name="module_secrets_manager_mysql"></a> [secrets\_manager\_mysql](#module\_secrets\_manager\_mysql) | terraform-aws-modules/secrets-manager/aws | ~> 1.0 |
+| <a name="module_secrets_manager_postgresql"></a> [secrets\_manager\_postgresql](#module\_secrets\_manager\_postgresql) | terraform-aws-modules/secrets-manager/aws | ~> 1.0 |
+| <a name="module_security_group"></a> [security\_group](#module\_security\_group) | terraform-aws-modules/security-group/aws | ~> 5.0 |
+| <a name="module_vpc"></a> [vpc](#module\_vpc) | terraform-aws-modules/vpc/aws | ~> 5.0 |
+| <a name="module_vpc_endpoints"></a> [vpc\_endpoints](#module\_vpc\_endpoints) | terraform-aws-modules/vpc/aws//modules/vpc-endpoints | ~> 5.0 |
+
+## Resources
+
+| Name | Type |
+|------|------|
+| [aws_kms_key.this](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/kms_key) | resource |
+| [aws_rds_cluster_parameter_group.postgresql](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/resources/rds_cluster_parameter_group) | resource |
+| [aws_availability_zones.available](https://registry.terraform.io/providers/hashicorp/aws/latest/docs/data-sources/availability_zones) | data source |
+
+## Inputs
+
+No inputs.
+
+## Outputs
+
+| Name | Description |
+|------|-------------|
+| <a name="output_dms_access_for_endpoint_iam_role_arn"></a> [dms\_access\_for\_endpoint\_iam\_role\_arn](#output\_dms\_access\_for\_endpoint\_iam\_role\_arn) | Amazon Resource Name (ARN) specifying the role |
+| <a name="output_dms_access_for_endpoint_iam_role_id"></a> [dms\_access\_for\_endpoint\_iam\_role\_id](#output\_dms\_access\_for\_endpoint\_iam\_role\_id) | Name of the IAM role |
+| <a name="output_dms_access_for_endpoint_iam_role_unique_id"></a> [dms\_access\_for\_endpoint\_iam\_role\_unique\_id](#output\_dms\_access\_for\_endpoint\_iam\_role\_unique\_id) | Stable and unique string identifying the role |
+| <a name="output_dms_cloudwatch_logs_iam_role_arn"></a> [dms\_cloudwatch\_logs\_iam\_role\_arn](#output\_dms\_cloudwatch\_logs\_iam\_role\_arn) | Amazon Resource Name (ARN) specifying the role |
+| <a name="output_dms_cloudwatch_logs_iam_role_id"></a> [dms\_cloudwatch\_logs\_iam\_role\_id](#output\_dms\_cloudwatch\_logs\_iam\_role\_id) | Name of the IAM role |
+| <a name="output_dms_cloudwatch_logs_iam_role_unique_id"></a> [dms\_cloudwatch\_logs\_iam\_role\_unique\_id](#output\_dms\_cloudwatch\_logs\_iam\_role\_unique\_id) | Stable and unique string identifying the role |
+| <a name="output_dms_vpc_iam_role_arn"></a> [dms\_vpc\_iam\_role\_arn](#output\_dms\_vpc\_iam\_role\_arn) | Amazon Resource Name (ARN) specifying the role |
+| <a name="output_dms_vpc_iam_role_id"></a> [dms\_vpc\_iam\_role\_id](#output\_dms\_vpc\_iam\_role\_id) | Name of the IAM role |
+| <a name="output_dms_vpc_iam_role_unique_id"></a> [dms\_vpc\_iam\_role\_unique\_id](#output\_dms\_vpc\_iam\_role\_unique\_id) | Stable and unique string identifying the role |
+| <a name="output_endpoints"></a> [endpoints](#output\_endpoints) | A map of maps containing the endpoints created and their full output of attributes and values |
+| <a name="output_replication_subnet_group_id"></a> [replication\_subnet\_group\_id](#output\_replication\_subnet\_group\_id) | The ID of the subnet group |
+| <a name="output_s3_endpoints"></a> [s3\_endpoints](#output\_s3\_endpoints) | A map of maps containing the S3 endpoints created and their full output of attributes and values |
+| <a name="output_serverless_replication_tasks"></a> [serverless\_replication\_tasks](#output\_serverless\_replication\_tasks) | A map of maps containing the serverless replication tasks created and their full output of attributes and values |
 <!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
 
 Apache-2.0 Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-aws-dms/blob/master/LICENSE).

--- a/examples/serverless/README.md
+++ b/examples/serverless/README.md
@@ -26,14 +26,14 @@ Note that this example may create resources which will incur monetary charges on
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.0 |
-| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.31 |
+| <a name="requirement_aws"></a> [aws](#requirement\_aws) | >= 5.32 |
 | <a name="requirement_random"></a> [random](#requirement\_random) | >= 3.0 |
 
 ## Providers
 
 | Name | Version |
 |------|---------|
-| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.31 |
+| <a name="provider_aws"></a> [aws](#provider\_aws) | >= 5.32 |
 
 ## Modules
 

--- a/examples/serverless/README.md
+++ b/examples/serverless/README.md
@@ -1,4 +1,4 @@
-# Complete AWS DMS Example
+# Serverless AWS DMS Example
 
 Configuration in this directory creates:
 

--- a/examples/serverless/README.md
+++ b/examples/serverless/README.md
@@ -1,0 +1,26 @@
+# Complete AWS DMS Example
+
+Configuration in this directory creates:
+
+- AWS IAM roles [necessary for AWS DMS](https://aws.amazon.com/premiumsupport/knowledge-center/dms-redshift-connectivity-failures/)
+- [AWS DMS subnet group](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_ReplicationInstance.VPC.html)
+- [AWS DMS serverless replication configuration](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Serverless.html)
+- Two [AWS DMS replication endpoints](https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Endpoints.Creating.html) - one `source` and one `target` to migrate data from an Aurora PostgreSQL cluster to Aurora MySQL cluster
+- Necessary supporting resources to demonstrate the capabilities of the module (VPC, Aurora clusters, security groups, etc.)
+
+## Usage
+
+To run this example you need to execute:
+
+```bash
+$ terraform init
+$ terraform plan
+$ terraform apply
+```
+
+Note that this example may create resources which will incur monetary charges on your AWS bill. Run `terraform destroy` when you no longer need these resources.
+
+<!-- BEGINNING OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+<!-- END OF PRE-COMMIT-TERRAFORM DOCS HOOK -->
+
+Apache-2.0 Licensed. See [LICENSE](https://github.com/terraform-aws-modules/terraform-aws-dms/blob/master/LICENSE).

--- a/examples/serverless/configs/table_mappings.json
+++ b/examples/serverless/configs/table_mappings.json
@@ -1,0 +1,12 @@
+{
+  "rules": [{
+    "rule-type": "selection",
+    "rule-id": "1",
+    "rule-name": "1",
+    "object-locator": {
+      "schema-name": "%",
+      "table-name": "%"
+    },
+    "rule-action": "include"
+  }]
+}

--- a/examples/serverless/configs/task_settings.json
+++ b/examples/serverless/configs/task_settings.json
@@ -1,0 +1,68 @@
+{
+  "TargetMetadata": {
+    "SupportLobs": true,
+    "FullLobMode": false,
+    "LobChunkSize": 64,
+    "LimitedSizeLobMode": true,
+    "LobMaxSize": 32,
+    "BatchApplyEnabled": true
+  },
+  "FullLoadSettings": {
+    "TargetTablePrepMode": "DO_NOTHING",
+    "CreatePkAfterFullLoad": false,
+    "StopTaskCachedChangesApplied": false,
+    "StopTaskCachedChangesNotApplied": false,
+    "MaxFullLoadSubTasks": 8,
+    "TransactionConsistencyTimeout": 600,
+    "CommitRate": 10000
+  },
+  "Logging": {
+    "EnableLogging": true
+  },
+  "ControlTablesSettings": {
+    "HistoryTimeslotInMinutes": 5,
+    "HistoryTableEnabled": false,
+    "SuspendedTablesTableEnabled": false,
+    "StatusTableEnabled": false
+  },
+  "StreamBufferSettings": {
+    "StreamBufferCount": 3,
+    "StreamBufferSizeInMB": 8
+  },
+  "ChangeProcessingTuning": {
+    "BatchApplyPreserveTransaction": true,
+    "BatchApplyTimeoutMin": 1,
+    "BatchApplyTimeoutMax": 30,
+    "BatchApplyMemoryLimit": 500,
+    "BatchSplitSize": 0,
+    "MinTransactionSize": 1000,
+    "CommitTimeout": 1,
+    "MemoryLimitTotal": 1024,
+    "MemoryKeepTime": 60,
+    "StatementCacheSize": 50
+  },
+  "ChangeProcessingDdlHandlingPolicy": {
+    "HandleSourceTableDropped": true,
+    "HandleSourceTableTruncated": true,
+    "HandleSourceTableAltered": true
+  },
+  "ErrorBehavior": {
+    "DataErrorPolicy": "LOG_ERROR",
+    "DataTruncationErrorPolicy": "LOG_ERROR",
+    "DataErrorEscalationPolicy": "SUSPEND_TABLE",
+    "DataErrorEscalationCount": 50,
+    "TableErrorPolicy": "SUSPEND_TABLE",
+    "TableErrorEscalationPolicy": "STOP_TASK",
+    "TableErrorEscalationCount": 50,
+    "RecoverableErrorCount": 0,
+    "RecoverableErrorInterval": 5,
+    "RecoverableErrorThrottling": true,
+    "RecoverableErrorThrottlingMax": 1800,
+    "ApplyErrorDeletePolicy": "IGNORE_RECORD",
+    "ApplyErrorInsertPolicy": "LOG_ERROR",
+    "ApplyErrorUpdatePolicy": "LOG_ERROR",
+    "ApplyErrorEscalationPolicy": "LOG_ERROR",
+    "ApplyErrorEscalationCount": 0,
+    "FullLoadIgnoreConflicts": true
+  }
+}

--- a/examples/serverless/main.tf
+++ b/examples/serverless/main.tf
@@ -1,0 +1,284 @@
+provider "aws" {
+  region = local.region
+}
+
+data "aws_availability_zones" "available" {}
+
+locals {
+  region = "us-east-1"
+  name   = "dms-ex-${basename(path.cwd)}"
+
+  vpc_cidr = "10.0.0.0/16"
+  azs      = slice(data.aws_availability_zones.available.names, 0, 3)
+
+  db_name     = "example"
+  db_username = "example"
+  db_password = "password123!" # do better!
+
+  tags = {
+    Name       = local.name
+    Example    = local.name
+    Repository = "https://github.com/terraform-aws-modules/terraform-aws-dms"
+  }
+}
+
+################################################################################
+# DMS Module
+################################################################################
+
+module "dms_aurora_postgresql_aurora_mysql" {
+  source = "../.."
+
+  # Subnet group
+  repl_subnet_group_name        = local.name
+  repl_subnet_group_description = "DMS Subnet group for ${local.name}"
+  repl_subnet_group_subnet_ids  = module.vpc.private_subnets
+
+  # Instance
+  create_repl_instance = false
+
+  # Access role
+  create_access_iam_role = true
+  access_secret_arns = [
+    module.secrets_manager_postgresql.secret_arn,
+    module.secrets_manager_mysql.secret_arn,
+  ]
+
+  # Endpoints
+  endpoints = {
+    postgresql-source = {
+      database_name               = local.db_name
+      endpoint_id                 = "${local.name}-postgresql-source"
+      endpoint_type               = "source"
+      engine_name                 = "aurora-postgresql"
+      extra_connection_attributes = "heartbeatFrequency=1;secretsManagerEndpointOverride=${module.vpc_endpoints.endpoints["secretsmanager"]["dns_entry"][0]["dns_name"]}"
+      secrets_manager_arn         = module.secrets_manager_postgresql.secret_arn
+
+      postgres_settings = {
+        capture_ddls        = false
+        heartbeat_enable    = true
+        heartbeat_frequency = 1
+      }
+
+      tags = { EndpointType = "postgresql-source" }
+    }
+
+    mysql-destination = {
+      database_name               = local.db_name
+      endpoint_id                 = "${local.name}-mysql-destination"
+      endpoint_type               = "target"
+      engine_name                 = "aurora"
+      extra_connection_attributes = "secretsManagerEndpointOverride=${module.vpc_endpoints.endpoints["secretsmanager"]["dns_entry"][0]["dns_name"]}"
+      secrets_manager_arn         = module.secrets_manager_mysql.secret_arn
+
+      tags = { EndpointType = "mysql-destination" }
+    }
+  }
+
+  replication_tasks = {
+    postgresql_mysql = {
+      replication_task_id       = "postgresql-to-mysql"
+      migration_type            = "full-load-and-cdc"
+      replication_task_settings = file("configs/task_settings.json")
+      table_mappings            = file("configs/table_mappings.json")
+      source_endpoint_key       = "postgresql-source"
+      target_endpoint_key       = "mysql-destination"
+
+      serverless_config = {
+        max_capacity_units     = 2
+        min_capacity_units     = 1
+        multi_az               = true
+        vpc_security_group_ids = [module.security_group["replication-configuration"].security_group_id]
+      }
+
+      tags = { Task = "PostgreSQL-to-MySQL" }
+    }
+  }
+
+  tags = local.tags
+}
+
+################################################################################
+# Supporting Resources
+################################################################################
+
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 5.0"
+
+  name = local.name
+  cidr = local.vpc_cidr
+
+  azs              = local.azs
+  public_subnets   = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 8, k)]
+  private_subnets  = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 8, k + 3)]
+  database_subnets = [for k, v in local.azs : cidrsubnet(local.vpc_cidr, 8, k + 6)]
+
+  enable_nat_gateway = true
+  single_nat_gateway = true
+
+  create_database_subnet_group = true
+
+  tags = local.tags
+}
+
+module "vpc_endpoints" {
+  source  = "terraform-aws-modules/vpc/aws//modules/vpc-endpoints"
+  version = "~> 5.0"
+
+  vpc_id                     = module.vpc.vpc_id
+  create_security_group      = true
+  security_group_name_prefix = "${local.name}-vpc-endpoints-"
+  security_group_description = "VPC endpoint security group"
+  security_group_rules = {
+    ingress_https = {
+      description = "HTTPS from VPC"
+      cidr_blocks = [module.vpc.vpc_cidr_block]
+    }
+  }
+
+  endpoints = {
+    secretsmanager = {
+      service_name = "com.amazonaws.${local.region}.secretsmanager"
+      subnet_ids   = module.vpc.private_subnets
+    }
+  }
+
+  tags = local.tags
+}
+
+module "security_group" {
+  source  = "terraform-aws-modules/security-group/aws"
+  version = "~> 5.0"
+
+  # Creates multiple
+  for_each = {
+    postgresql-source         = ["postgresql-tcp"]
+    mysql-destination         = ["mysql-tcp"]
+    replication-configuration = ["postgresql-tcp", "mysql-tcp"]
+  }
+
+  name        = "${local.name}-${each.key}"
+  description = "Security group for ${each.key}"
+  vpc_id      = module.vpc.vpc_id
+
+  ingress_cidr_blocks = [module.vpc.vpc_cidr_block]
+  ingress_rules       = each.value
+
+  egress_cidr_blocks = ["0.0.0.0/0"]
+  egress_rules       = ["all-all"]
+
+  tags = local.tags
+}
+
+resource "aws_rds_cluster_parameter_group" "postgresql" {
+  name   = "${local.name}-postgresql"
+  family = "aurora-postgresql14"
+
+  parameter {
+    name         = "rds.logical_replication"
+    value        = 1
+    apply_method = "pending-reboot"
+  }
+
+  parameter {
+    name  = "wal_sender_timeout"
+    value = 0
+  }
+
+  tags = local.tags
+}
+
+module "rds_aurora" {
+  source  = "terraform-aws-modules/rds-aurora/aws"
+  version = "~> 8.0"
+
+  # Creates multiple
+  for_each = {
+    postgresql-source = {
+      engine                          = "aurora-postgresql"
+      engine_version                  = "14.7"
+      enabled_cloudwatch_logs_exports = ["postgresql"]
+    },
+    mysql-destination = {
+      engine                          = "aurora-mysql"
+      engine_version                  = "8.0"
+      enabled_cloudwatch_logs_exports = ["general", "error", "slowquery"]
+    }
+  }
+
+  name                        = "${local.name}-${each.key}"
+  database_name               = local.db_name
+  master_username             = local.db_username
+  master_password             = local.db_password
+  manage_master_user_password = false
+  apply_immediately           = true
+
+  engine                          = each.value.engine
+  engine_version                  = each.value.engine_version
+  instance_class                  = "db.t3.medium"
+  instances                       = { 1 = {}, 2 = {} }
+  storage_encrypted               = true
+  skip_final_snapshot             = true
+  db_cluster_parameter_group_name = each.key == "postgresql-source" ? aws_rds_cluster_parameter_group.postgresql.id : null
+
+  vpc_id                 = module.vpc.vpc_id
+  subnets                = module.vpc.database_subnets
+  db_subnet_group_name   = module.vpc.database_subnet_group_name
+  create_db_subnet_group = false
+  create_security_group  = false
+  vpc_security_group_ids = [module.security_group[each.key].security_group_id]
+
+  tags = local.tags
+}
+
+resource "aws_kms_key" "this" {
+  description         = "KMS CMK for ${local.name}"
+  enable_key_rotation = true
+
+  tags = local.tags
+}
+
+module "secrets_manager_postgresql" {
+  source  = "terraform-aws-modules/secrets-manager/aws"
+  version = "~> 1.0"
+
+  name_prefix = "PostgreSQL-${local.name}-"
+  description = "Secret for ${local.name}"
+
+  # Secret
+  recovery_window_in_days = 0
+  secret_string = jsonencode(
+    {
+      username = local.db_username
+      password = local.db_password
+      port     = 5432
+      host     = module.rds_aurora["postgresql-source"].cluster_endpoint
+    }
+  )
+  kms_key_id = aws_kms_key.this.id
+
+  tags = local.tags
+}
+
+module "secrets_manager_mysql" {
+  source  = "terraform-aws-modules/secrets-manager/aws"
+  version = "~> 1.0"
+
+  name_prefix = "MySQL-${local.name}-"
+  description = "Secret for ${local.name}"
+
+  # Secret
+  recovery_window_in_days = 0
+  secret_string = jsonencode(
+    {
+      username = local.db_username
+      password = local.db_password
+      port     = 3306
+      host     = module.rds_aurora["mysql-destination"].cluster_endpoint
+    }
+  )
+  kms_key_id = aws_kms_key.this.id
+
+  tags = local.tags
+}

--- a/examples/serverless/outputs.tf
+++ b/examples/serverless/outputs.tf
@@ -1,0 +1,89 @@
+################################################################################
+# IAM Roles
+################################################################################
+
+# DMS Endpoint
+output "dms_access_for_endpoint_iam_role_arn" {
+  description = "Amazon Resource Name (ARN) specifying the role"
+  value       = module.dms_aurora_postgresql_aurora_mysql.dms_access_for_endpoint_iam_role_arn
+}
+
+output "dms_access_for_endpoint_iam_role_id" {
+  description = "Name of the IAM role"
+  value       = module.dms_aurora_postgresql_aurora_mysql.dms_access_for_endpoint_iam_role_id
+}
+
+output "dms_access_for_endpoint_iam_role_unique_id" {
+  description = "Stable and unique string identifying the role"
+  value       = module.dms_aurora_postgresql_aurora_mysql.dms_access_for_endpoint_iam_role_unique_id
+}
+
+# DMS CloudWatch Logs
+output "dms_cloudwatch_logs_iam_role_arn" {
+  description = "Amazon Resource Name (ARN) specifying the role"
+  value       = module.dms_aurora_postgresql_aurora_mysql.dms_cloudwatch_logs_iam_role_arn
+}
+
+output "dms_cloudwatch_logs_iam_role_id" {
+  description = "Name of the IAM role"
+  value       = module.dms_aurora_postgresql_aurora_mysql.dms_cloudwatch_logs_iam_role_id
+}
+
+output "dms_cloudwatch_logs_iam_role_unique_id" {
+  description = "Stable and unique string identifying the role"
+  value       = module.dms_aurora_postgresql_aurora_mysql.dms_cloudwatch_logs_iam_role_unique_id
+}
+
+# DMS VPC
+output "dms_vpc_iam_role_arn" {
+  description = "Amazon Resource Name (ARN) specifying the role"
+  value       = module.dms_aurora_postgresql_aurora_mysql.dms_vpc_iam_role_arn
+}
+
+output "dms_vpc_iam_role_id" {
+  description = "Name of the IAM role"
+  value       = module.dms_aurora_postgresql_aurora_mysql.dms_vpc_iam_role_id
+}
+
+output "dms_vpc_iam_role_unique_id" {
+  description = "Stable and unique string identifying the role"
+  value       = module.dms_aurora_postgresql_aurora_mysql.dms_vpc_iam_role_unique_id
+}
+
+################################################################################
+# Subnet group
+################################################################################
+
+output "replication_subnet_group_id" {
+  description = "The ID of the subnet group"
+  value       = module.dms_aurora_postgresql_aurora_mysql.replication_subnet_group_id
+}
+
+################################################################################
+# Endpoint
+################################################################################
+
+output "endpoints" {
+  description = "A map of maps containing the endpoints created and their full output of attributes and values"
+  value       = module.dms_aurora_postgresql_aurora_mysql.endpoints
+  sensitive   = true
+}
+
+################################################################################
+# S3 Endpoint
+################################################################################
+
+output "s3_endpoints" {
+  description = "A map of maps containing the S3 endpoints created and their full output of attributes and values"
+  value       = module.dms_aurora_postgresql_aurora_mysql.s3_endpoints
+  sensitive   = true
+}
+
+################################################################################
+# Replication Task
+################################################################################
+
+output "serverless_replication_tasks" {
+  description = "A map of maps containing the serverless replication tasks created and their full output of attributes and values"
+  value       = module.dms_aurora_postgresql_aurora_mysql.serverless_replication_tasks
+}

--- a/examples/serverless/versions.tf
+++ b/examples/serverless/versions.tf
@@ -1,0 +1,14 @@
+terraform {
+  required_version = ">= 1.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = ">= 5.31"
+    }
+    random = {
+      source  = "hashicorp/random"
+      version = ">= 3.0"
+    }
+  }
+}

--- a/examples/serverless/versions.tf
+++ b/examples/serverless/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.31"
+      version = ">= 5.32"
     }
     random = {
       source  = "hashicorp/random"

--- a/main.tf
+++ b/main.tf
@@ -384,7 +384,7 @@ resource "aws_dms_s3_endpoint" "this" {
 ################################################################################
 
 resource "aws_dms_replication_task" "this" {
-  for_each = { for k, v in var.replication_tasks : k => v if var.create && ! contains(keys(v), "serverless_config") }
+  for_each = { for k, v in var.replication_tasks : k => v if var.create && !contains(keys(v), "serverless_config") }
 
   cdc_start_position        = try(each.value.cdc_start_position, null)
   cdc_start_time            = try(each.value.cdc_start_time, null)

--- a/main.tf
+++ b/main.tf
@@ -384,7 +384,7 @@ resource "aws_dms_s3_endpoint" "this" {
 ################################################################################
 
 resource "aws_dms_replication_task" "this" {
-  for_each = { for k, v in var.replication_tasks : k => v if var.create && v.serverless_config == null }
+  for_each = { for k, v in var.replication_tasks : k => v if var.create && ! contains(keys(v), "serverless_config") }
 
   cdc_start_position        = try(each.value.cdc_start_position, null)
   cdc_start_time            = try(each.value.cdc_start_time, null)
@@ -404,7 +404,7 @@ resource "aws_dms_replication_task" "this" {
 # Replication Task - Serverless
 ################################################################################
 resource "aws_dms_replication_config" "this" {
-  for_each = { for k, v in var.replication_tasks : k => v if var.create && v.serverless_config != null }
+  for_each = { for k, v in var.replication_tasks : k => v if var.create && contains(keys(v), "serverless_config") }
 
   replication_config_identifier = each.value.replication_task_id
   resource_identifier           = each.value.replication_task_id

--- a/outputs.tf
+++ b/outputs.tf
@@ -112,6 +112,11 @@ output "replication_tasks" {
   value       = aws_dms_replication_task.this
 }
 
+output "serverless_replication_tasks" {
+  description = "value"
+  value       = aws_dms_replication_config.this
+}
+
 ################################################################################
 # Event Subscription
 ################################################################################

--- a/outputs.tf
+++ b/outputs.tf
@@ -113,7 +113,7 @@ output "replication_tasks" {
 }
 
 output "serverless_replication_tasks" {
-  description = "value"
+  description = "A map of maps containing the serverless replication tasks (replication_config) created and their full output of attributes and values"
   value       = aws_dms_replication_config.this
 }
 

--- a/variables.tf
+++ b/variables.tf
@@ -78,6 +78,12 @@ variable "repl_subnet_group_tags" {
 # Instance
 ################################################################################
 
+variable "create_repl_instance" {
+  description = "Indicates whether a replication instace should be created"
+  type        = bool
+  default     = true
+}
+
 variable "repl_instance_allocated_storage" {
   description = "The amount of storage (in gigabytes) to be initially allocated for the replication instance. Min: 5, Max: 6144, Default: 50"
   type        = number

--- a/versions.tf
+++ b/versions.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = ">= 5.31"
+      version = ">= 5.32"
     }
     time = {
       source  = "hashicorp/time"


### PR DESCRIPTION
## Description
Add support for DMS Serverless Replication tasks using `aws_dms_replication_config`.

- Add optional creation of a replication instance, default is true to maintain current behaviour
- Allow setting `serverless_config` parameters on `replication_tasks` to make the task a Serverless configuration instead of a replication task

## Motivation and Context
resolves #53 

## Breaking Changes
No breaking changes, default behaviour remains the same.
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [x] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [x] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
Tested using existing and new examples.
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
