### PR TITLE
feat: We make role names variable (#1)

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -80,7 +80,7 @@ resource "time_sleep" "wait_for_dependency_resources" {
 resource "aws_iam_role" "dms_access_for_endpoint" {
   count = var.create && var.create_iam_roles ? 1 : 0
 
-  name                  = "dms-access-for-endpoint"
+  name                  = "${var.repl_instance_id}-access-for-endpoint"
   description           = "DMS IAM role for endpoint access permissions"
   permissions_boundary  = var.iam_role_permissions_boundary
   assume_role_policy    = var.enable_redshift_target_permissions ? data.aws_iam_policy_document.dms_assume_role_redshift[0].json : data.aws_iam_policy_document.dms_assume_role[0].json
@@ -94,7 +94,7 @@ resource "aws_iam_role" "dms_access_for_endpoint" {
 resource "aws_iam_role" "dms_cloudwatch_logs_role" {
   count = var.create && var.create_iam_roles ? 1 : 0
 
-  name                  = "dms-cloudwatch-logs-role"
+  name                  = "${var.repl_instance_id}-cloudwatch-logs-role"
   description           = "DMS IAM role for CloudWatch logs permissions"
   permissions_boundary  = var.iam_role_permissions_boundary
   assume_role_policy    = data.aws_iam_policy_document.dms_assume_role[0].json
@@ -108,7 +108,7 @@ resource "aws_iam_role" "dms_cloudwatch_logs_role" {
 resource "aws_iam_role" "dms_vpc_role" {
   count = var.create && var.create_iam_roles ? 1 : 0
 
-  name                  = "dms-vpc-role"
+  name                  = "${var.repl_instance_id}-vpc-role"
   description           = "DMS IAM role for VPC permissions"
   permissions_boundary  = var.iam_role_permissions_boundary
   assume_role_policy    = data.aws_iam_policy_document.dms_assume_role[0].json


### PR DESCRIPTION
## Description
Adding variables in IAM Role names

## Motivation and Context
We have multiple DMS instances for multiple teams, and they would like their IAM Roles to be separate.

## Breaking Changes
No breaking changes, however care needs to be taken if the `repl_instance_id` is being used.

## How Has This Been Tested?
We have tested it through usage.