### PR TITLE
chore: Update Role Names

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,6 +366,7 @@ No modules.
 | <a name="input_access_target_kinesis_arns"></a> [access\_target\_kinesis\_arns](#input\_access\_target\_kinesis\_arns) | A list of Kinesis ARNs the access IAM role is permitted to access | `list(string)` | `[]` | no |
 | <a name="input_access_target_s3_bucket_arns"></a> [access\_target\_s3\_bucket\_arns](#input\_access\_target\_s3\_bucket\_arns) | A list of S3 bucket ARNs the access IAM role is permitted to access | `list(string)` | `[]` | no |
 | <a name="input_certificates"></a> [certificates](#input\_certificates) | Map of objects that define the certificates to be created | `map(any)` | `{}` | no |
+| <a name="input_cloudwatch_logs_role_name"></a> [cloudwatch\_logs\_role\_name](#input\_cloudwatch\_logs\_role\_name) | Name to use on IAM role created | `string` | `"dms-cloudwatch-logs-role"` | no |
 | <a name="input_create"></a> [create](#input\_create) | Determines whether resources will be created | `bool` | `true` | no |
 | <a name="input_create_access_iam_role"></a> [create\_access\_iam\_role](#input\_create\_access\_iam\_role) | Determines whether the ECS task definition IAM role should be created | `bool` | `true` | no |
 | <a name="input_create_access_policy"></a> [create\_access\_policy](#input\_create\_access\_policy) | Determines whether the IAM policy should be created | `bool` | `true` | no |
@@ -402,6 +403,7 @@ No modules.
 | <a name="input_replication_tasks"></a> [replication\_tasks](#input\_replication\_tasks) | Map of objects that define the replication tasks to be created | `any` | `{}` | no |
 | <a name="input_s3_endpoints"></a> [s3\_endpoints](#input\_s3\_endpoints) | Map of objects that define the S3 endpoints to be created | `any` | `{}` | no |
 | <a name="input_tags"></a> [tags](#input\_tags) | A map of tags to use on all resources | `map(string)` | `{}` | no |
+| <a name="input_vpc_role_name"></a> [vpc\_role\_name](#input\_vpc\_role\_name) | Name to use on IAM role created | `string` | `"dms-vpc-role"` | no |
 
 ## Outputs
 

--- a/main.tf
+++ b/main.tf
@@ -94,7 +94,7 @@ resource "aws_iam_role" "dms_access_for_endpoint" {
 resource "aws_iam_role" "dms_cloudwatch_logs_role" {
   count = var.create && var.create_iam_roles ? 1 : 0
 
-  name                  = "dms-cloudwatch-logs-role"
+  name                  = var.cloudwatch_logs_role_name
   description           = "DMS IAM role for CloudWatch logs permissions"
   permissions_boundary  = var.iam_role_permissions_boundary
   assume_role_policy    = data.aws_iam_policy_document.dms_assume_role[0].json
@@ -108,7 +108,7 @@ resource "aws_iam_role" "dms_cloudwatch_logs_role" {
 resource "aws_iam_role" "dms_vpc_role" {
   count = var.create && var.create_iam_roles ? 1 : 0
 
-  name                  = "dms-vpc-role"
+  name                  = var.vpc_role_name
   description           = "DMS IAM role for VPC permissions"
   permissions_boundary  = var.iam_role_permissions_boundary
   assume_role_policy    = data.aws_iam_policy_document.dms_assume_role[0].json

--- a/variables.tf
+++ b/variables.tf
@@ -347,3 +347,15 @@ variable "access_target_dynamodb_table_arns" {
   type        = list(string)
   default     = []
 }
+
+variable "vpc_role_name" {
+  description = "Name to use on IAM role created"
+  type        = string
+  default     = "dms-vpc-role"
+}
+
+variable "cloudwatch_logs_role_name" {
+  description = "Name to use on IAM role created"
+  type        = string
+  default     = "dms-cloudwatch-logs-role"
+}


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
We have a team with a few team members, and when we use this module at the same time, we get the error: Role with name dms-cloudwatch-logs-role already exists. and Role with name dms-vpc-role already exists.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
These changes provide the opportunity to rename role names.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? --> NO
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
