### PR TITLE
fix: S3 target iam policy

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -593,18 +593,31 @@ data "aws_iam_policy_document" "access" {
 
   # https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Target.S3.html#CHAP_Target.S3.Prerequisites
   dynamic "statement" {
-    for_each = length(var.access_target_s3_bucket_arns) > 0 ? [1] : []
+    for_each = length(var.access_target_s3_bucket_arns) > 0 ? var.access_target_s3_bucket_arns : []
+    iterator = access_target_s3_bucket_arn
 
     content {
-      sid = "S3Target"
+      sid = "S3ObjectTarget"
       actions = [
-        "s3:ListBucket",
         "s3:PutObject",
         "s3:DeleteObject",
         "s3:PutObjectTagging",
       ]
-      resources = var.access_target_s3_bucket_arns
+      resources = toset(["${access_target_s3_bucket_arn.value}/*"])
     }
+  }
+  dynamic "statement" {
+    for_each = length(var.access_target_s3_bucket_arns) > 0 ? var.access_target_s3_bucket_arns : []
+    iterator = access_target_s3_bucket_arn
+
+    content {
+      sid = "S3BucketTarget"
+      actions = [
+        "s3:ListBucket",
+      ]
+      resources = toset([access_target_s3_bucket_arn.value])
+    }
+
   }
 
   # https://docs.aws.amazon.com/dms/latest/userguide/CHAP_Target.Elasticsearch.html#CHAP_Target.Elasticsearch.Prerequisites


### PR DESCRIPTION
## Description
Just fixing the iam policy created when S3 bucket target is set

## Motivation and Context
https://github.com/terraform-aws-modules/terraform-aws-dms/issues/65

## Breaking Changes
N/A
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
