### PR TITLE
fix: solved warning depreciated property managed_policy_arns with aws…

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -80,42 +80,56 @@ resource "time_sleep" "wait_for_dependency_resources" {
 resource "aws_iam_role" "dms_access_for_endpoint" {
   count = var.create && var.create_iam_roles ? 1 : 0
 
-  name                  = "dms-access-for-endpoint"
+  name                  = "dms-access-for-endpoint2"
   description           = "DMS IAM role for endpoint access permissions"
   permissions_boundary  = var.iam_role_permissions_boundary
   assume_role_policy    = var.enable_redshift_target_permissions ? data.aws_iam_policy_document.dms_assume_role_redshift[0].json : data.aws_iam_policy_document.dms_assume_role[0].json
-  managed_policy_arns   = ["arn:${local.partition}:iam::aws:policy/service-role/AmazonDMSRedshiftS3Role"]
   force_detach_policies = true
-
   tags = merge(var.tags, var.iam_role_tags)
+}
+
+# Attach AmazonDMSRedshiftS3Role to endpoint role
+resource "aws_iam_role_policy_attachments_exclusive" "amazon_dms_redshift_S3_role_attach" {
+  policy_arns =  ["arn:${local.partition}:iam::aws:policy/service-role/AmazonDMSRedshiftS3Role"]
+  role_name = aws_iam_role.dms_access_for_endpoint[0].name
 }
 
 # DMS CloudWatch Logs
 resource "aws_iam_role" "dms_cloudwatch_logs_role" {
   count = var.create && var.create_iam_roles ? 1 : 0
 
-  name                  = "dms-cloudwatch-logs-role"
+  name                  = "dms-cloudwatch-logs-role3"
   description           = "DMS IAM role for CloudWatch logs permissions"
   permissions_boundary  = var.iam_role_permissions_boundary
   assume_role_policy    = data.aws_iam_policy_document.dms_assume_role[0].json
-  managed_policy_arns   = ["arn:${local.partition}:iam::aws:policy/service-role/AmazonDMSCloudWatchLogsRole"]
   force_detach_policies = true
 
   tags = merge(var.tags, var.iam_role_tags)
+}
+
+# Attach AmazonDMSCloudWatchLogsRole to endpoint role
+resource "aws_iam_role_policy_attachments_exclusive" "amazon_dms_cloud_watch_logs_role_attach" {
+  policy_arns =  ["arn:${local.partition}:iam::aws:policy/service-role/AmazonDMSCloudWatchLogsRole"]
+  role_name = aws_iam_role.dms_cloudwatch_logs_role[0].name
 }
 
 # DMS VPC
 resource "aws_iam_role" "dms_vpc_role" {
   count = var.create && var.create_iam_roles ? 1 : 0
 
-  name                  = "dms-vpc-role"
+  name                  = "dms-vpc-role2"
   description           = "DMS IAM role for VPC permissions"
   permissions_boundary  = var.iam_role_permissions_boundary
   assume_role_policy    = data.aws_iam_policy_document.dms_assume_role[0].json
-  managed_policy_arns   = ["arn:${local.partition}:iam::aws:policy/service-role/AmazonDMSVPCManagementRole"]
   force_detach_policies = true
 
   tags = merge(var.tags, var.iam_role_tags)
+}
+
+# Attach AmazonDMSVPCManagementRole to endpoint role
+resource "aws_iam_role_policy_attachments_exclusive" "amazon_dms_vpc_management_role_attach" {
+  policy_arns   = ["arn:${local.partition}:iam::aws:policy/service-role/AmazonDMSVPCManagementRole"]
+  role_name = aws_iam_role.dms_vpc_role[0].name
 }
 
 ################################################################################
@@ -392,10 +406,10 @@ resource "aws_dms_replication_task" "this" {
   replication_instance_arn  = aws_dms_replication_instance.this[0].replication_instance_arn
   replication_task_id       = each.value.replication_task_id
   replication_task_settings = try(each.value.replication_task_settings, null)
-  source_endpoint_arn       = try(each.value.source_endpoint_arn, aws_dms_endpoint.this[each.value.source_endpoint_key].endpoint_arn, aws_dms_s3_endpoint.this[each.value.source_endpoint_key].endpoint_arn)
+  source_endpoint_arn       = try(aws_dms_endpoint.this[each.value.source_endpoint_key].endpoint_arn, aws_dms_s3_endpoint.this[each.value.source_endpoint_key].endpoint_arn)
   start_replication_task    = try(each.value.start_replication_task, null)
   table_mappings            = try(each.value.table_mappings, null)
-  target_endpoint_arn       = try(each.value.target_endpoint_arn, aws_dms_endpoint.this[each.value.target_endpoint_key].endpoint_arn, aws_dms_s3_endpoint.this[each.value.target_endpoint_key].endpoint_arn)
+  target_endpoint_arn       = try(aws_dms_endpoint.this[each.value.target_endpoint_key].endpoint_arn, aws_dms_s3_endpoint.this[each.value.target_endpoint_key].endpoint_arn)
 
   tags = merge(var.tags, try(each.value.tags, {}))
 }
@@ -410,8 +424,8 @@ resource "aws_dms_replication_config" "this" {
   resource_identifier           = each.value.replication_task_id
 
   replication_type    = each.value.migration_type
-  source_endpoint_arn = try(each.value.source_endpoint_arn, aws_dms_endpoint.this[each.value.source_endpoint_key].endpoint_arn, aws_dms_s3_endpoint.this[each.value.source_endpoint_key].endpoint_arn)
-  target_endpoint_arn = try(each.value.target_endpoint_arn, aws_dms_endpoint.this[each.value.target_endpoint_key].endpoint_arn, aws_dms_s3_endpoint.this[each.value.target_endpoint_key].endpoint_arn)
+  source_endpoint_arn = try(aws_dms_endpoint.this[each.value.source_endpoint_key].endpoint_arn, aws_dms_s3_endpoint.this[each.value.source_endpoint_key].endpoint_arn)
+  target_endpoint_arn = try(aws_dms_endpoint.this[each.value.target_endpoint_key].endpoint_arn, aws_dms_s3_endpoint.this[each.value.target_endpoint_key].endpoint_arn)
   table_mappings      = try(each.value.table_mappings, null)
 
   replication_settings  = try(each.value.replication_task_settings, null)


### PR DESCRIPTION

## Description
<!--- Describe your changes in detail -->
fix: solved warning depreciated property managed_policy_arns with aws_iam_role_policy_attachments_exclusive

## Motivation and Context
The property is managed_policy_arns deprecated, generating a warning in the console

<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [x] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
