### PR TITLE
fix: Typo in variable desc

### DIFF
--- a/variables.tf
+++ b/variables.tf
@@ -79,7 +79,7 @@ variable "repl_subnet_group_tags" {
 ################################################################################
 
 variable "create_repl_instance" {
-  description = "Indicates whether a replication instace should be created"
+  description = "Indicates whether a replication instance should be created"
   type        = bool
   default     = true
 }


### PR DESCRIPTION
## Description
Fix a typo in a variable description

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
Typos are bad :)

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->

## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
