### PR TITLE
Introduce a replace trigger in endpoints change

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -317,7 +317,18 @@ resource "aws_dms_endpoint" "this" {
   ssl_mode                        = try(each.value.ssl_mode, null)
   username                        = try(each.value.username, null)
 
+  lifecycle {
+    replace_triggered_by = [ random_id.dms_endpoint_replace_trigger ]
+  }
+
   tags = merge(var.tags, try(each.value.tags, {}))
+}
+
+resource "random_id" "dms_endpoint_replace_trigger" {
+  keepers = {
+    settings_json = jsonencode(var.endpoints)
+  }
+  byte_length = 8
 }
 
 ################################################################################


### PR DESCRIPTION
## Description
<!--- Describe your changes in detail -->
The change introduces a replace trigger to force ls endpoints replacement if we get a new changes in the endpoints config.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
This fix is a workaround for the issue https://github.com/hashicorp/terraform-provider-aws/issues/35834 in the aws provider which many users are struggling with at the moment. The best is to fix the issue in the terraform aws provider but this could help meanwhile until the issue is picket from aws provider side.

## Breaking Changes
<!-- Does this break backwards compatibility with the current major version? -->
<!-- If so, please provide an explanation why it is necessary. -->
No
## How Has This Been Tested?
- [ ] I have updated at least one of the `examples/*` to demonstrate and validate my change(s)
- [ ] I have tested and validated these changes using one or more of the provided `examples/*` projects
<!--- Users should start with an existing example as its written, deploy it, then check their changes against it -->
<!--- This will highlight breaking/disruptive changes. Once you have checked, deploy your changes to verify -->
<!--- Please describe how you tested your changes -->
- [ ] I have executed `pre-commit run -a` on my pull request
<!--- Please see https://github.com/antonbabenko/pre-commit-terraform#how-to-install for how to install -->
